### PR TITLE
WIP add test to ensure wallet will start up with pluto instances

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -41,6 +41,7 @@
     "@pluto-encrypted/leveldb": "1.12.1"
   },
   "devDependencies": {
+    "@atala/prism-wallet-sdk": "^4.0.0",
     "@pluto-encrypted/encryption": "1.11.0",
     "@pluto-encrypted/indexdb": "1.12.1",
     "@pluto-encrypted/inmemory": "1.12.1",
@@ -51,7 +52,6 @@
     "level": "^6.0.1"
   },
   "dependencies": {
-    "@atala/prism-wallet-sdk": "^4.0.0",
     "@pluto-encrypted/encryption": "1.11.0",
     "@pluto-encrypted/shared": "1.11.3",
     "@pluto-encrypted/schemas": "^1.0.0",

--- a/packages/leveldb/tests/init.test.ts
+++ b/packages/leveldb/tests/init.test.ts
@@ -17,7 +17,7 @@ const defaultPassword = Buffer.from(keyData);
 
 describe("Testing suite", () => {
 
-  it('should be able to instanciate multiple databases in the same thread', async ({ expect }) => {
+  it('should be able to instantiate multiple databases in the same thread', async ({ expect }) => {
     if (fs.existsSync("./db1")) {
       fs.rmdirSync("./db1", { recursive: true })
     }

--- a/packages/leveldb/tests/setup.ts
+++ b/packages/leveldb/tests/setup.ts
@@ -2,7 +2,7 @@ import "fake-indexeddb/auto";
 import { TextEncoder, TextDecoder } from "util";
 import { addRxPlugin } from "rxdb";
 import { RxDBDevModePlugin } from "rxdb/plugins/dev-mode";
-import nodeCrypto from "crypto";
+import { getRandomValues } from "crypto";
 
 if (process.env.NODE_ENV === "debug") {
   addRxPlugin(RxDBDevModePlugin);
@@ -10,7 +10,7 @@ if (process.env.NODE_ENV === "debug") {
 
 Object.defineProperty(globalThis, "crypto", {
   value: {
-    getRandomValues: (arr) => nodeCrypto.getRandomValues(arr),
+    getRandomValues: (arr) => getRandomValues(arr),
   },
 });
 


### PR DESCRIPTION
I'm getting up to speed again (slooow).

The problem I saw was that the SDK was not starting up with my pluto instance. It was complaining about `getAllMediators` not being a function on `this.pluto` somewhere deep in the SDK ...

I thought it would be good to have an integration test that checks that these pluto instances will in fact play well with SDK. There's some tests which check you can instantiate, but we need tests which check that the SDK will `start()`

This is a sketch... I'm struggling with some Typescript here